### PR TITLE
Set default asyncio_default_fixture_loop_scope for pytest

### DIFF
--- a/{{ cookiecutter.domain }}/setup.cfg
+++ b/{{ cookiecutter.domain }}/setup.cfg
@@ -13,6 +13,7 @@ show_missing = true
 [tool:pytest]
 testpaths = tests
 norecursedirs = .git
+asyncio_default_fixture_loop_scope = function
 asyncio_mode = auto
 addopts =
     -p syrupy


### PR DESCRIPTION
Motivation: otherwise, modern versions of pytest (tested with 8.3.4) complain when tests are run:

```
site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
```